### PR TITLE
fix multi_single_vectorized_wrapper

### DIFF
--- a/one_policy_to_run_them_all/environments/multi_robot/multi_single_vectorized_wrapper.py
+++ b/one_policy_to_run_them_all/environments/multi_robot/multi_single_vectorized_wrapper.py
@@ -1,15 +1,24 @@
+import os
 from copy import deepcopy
 import numpy as np
 import gymnasium as gym
 
 
 class MultiSingleVectorEnv(gym.vector.SyncVectorEnv):
-    def __init__(self, env_fns, observation_space=None, action_space=None, copy=True):
+    def __init__(self, env_fns, observation_space=None, action_space=None, copy=True, nr_envs=1, file_name="multi_render.txt"):
         super().__init__(env_fns, observation_space, action_space, copy)
+        self.nr_envs = len(env_fns)
+        self.file_name = file_name
+        self.active_env_id = self.get_env_to_render()
 
-        self.active_env_id = 0
 
-
+    def get_env_to_render(self):
+        if os.path.isfile(self.file_name):
+            with open(self.file_name, "r") as f:
+                env_to_render = f.read()
+            return int(min(env_to_render, self.nr_envs-1))
+        return 0
+    
     def step_async(self, action):
         self.action = action[0]
 


### PR DESCRIPTION
Added code to ensure that when environment.multi_render = True, the multi_render.txt file is correctly read in the MultiSingleVectorEnv class. This update enables the environment to function correctly even when the robot index is not 0.